### PR TITLE
fix(actions): Update deprecated deployment actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,11 +21,11 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
The deployment workflow was failing because it used deprecated versions of GitHub Actions. This commit updates the actions to their latest non-deprecated versions to resolve the issue.

- `actions/upload-pages-artifact` has been updated from `v2` to `v3`.
- `actions/deploy-pages` has been updated from `v2` to `v4`.